### PR TITLE
Tree expand/collapse support

### DIFF
--- a/Source/DskImage.pas
+++ b/Source/DskImage.pas
@@ -1519,7 +1519,7 @@ var
 begin
   Result := 1;
   DeclaredSize := FDCSectorSizes[FDCSize];
-  if DataSize mod DeclaredSize <> 0 then exit;
+  if (DeclaredSize = 0) or (DataSize mod DeclaredSize <> 0) then exit;
   Result := DataSize div DeclaredSize;
 end;
 

--- a/Source/FormatAnalysis.pas
+++ b/Source/FormatAnalysis.pas
@@ -162,6 +162,13 @@ begin
   end;
 
   for TIdx := 0 to Side.Tracks - 2 do
+    if (Side.Track[TIdx].Sectors = 18) and (Side.Track[TIdx].Sector[0].DataSize = 256) then
+      begin
+        Result := Format('Alkatraz CPC (18 sector T%d)', [TIdx]);
+        exit;
+      end;
+
+    for TIdx := 0 to Side.Tracks - 2 do
     if (Side.Track[TIdx].Sectors = 18) and (Side.Track[TIdx].SectorSize = 256) then
       if (Side.Track[TIdx + 1].Sectors > 0) and (Side.Track[TIdx + 1].Sector[0].FDCStatus[2] = 64) then
       begin
@@ -376,9 +383,9 @@ begin
 
   // W.R.M. (Martech)
   if (Side.Tracks > 9) and (Side.Track[9].Sectors > 9) and (Side.Track[8].Sector[9].DataSize > 128) then
-    if StrBufPos(Side.Track[0].Sector[9].Data, 'W.R.M Disc') = 0 then
-      if StrBufPos(Side.Track[0].Sector[9].Data, 'Protection') > 0 then
-        if StrBufPos(Side.Track[0].Sector[9].Data, 'System (c) 1987') > 0 then
+    if StrBufPos(Side.Track[8].Sector[9].Data, 'W.R.M Disc') = 0 then
+      if StrBufPos(Side.Track[8].Sector[9].Data, 'Protection') > 0 then
+        if StrBufPos(Side.Track[8].Sector[9].Data, 'System (c) 1987') > 0 then
         begin
           Result := 'W.R.M Disc Protection (signed T0/S9 +0)';
           exit;

--- a/Source/Main.lfm
+++ b/Source/Main.lfm
@@ -11,10 +11,10 @@ object frmMain: TfrmMain
   Font.Pitch = fpVariable
   Font.Quality = fqDraft
   Menu = mnuMain
+  Position = poDesktopCenter
+  LCLVersion = '4.2.0.0'
   OnClose = FormClose
   OnCreate = FormCreate
-  Position = poDesktopCenter
-  LCLVersion = '3.2.0.0'
   object splVertical: TSplitter
     Left = 180
     Height = 329
@@ -46,9 +46,9 @@ object frmMain: TfrmMain
       ScrollBars = ssAutoVertical
       ShowLines = False
       TabOrder = 1
+      Options = [tvoAutoItemHeight, tvoKeepCollapsedNodes, tvoReadOnly, tvoRowSelect, tvoShowButtons, tvoShowRoot, tvoToolTips, tvoThemedDraw]
       OnChange = tvwMainChange
       OnDblClick = tvwMainDblClick
-      Options = [tvoAutoItemHeight, tvoKeepCollapsedNodes, tvoReadOnly, tvoRowSelect, tvoShowButtons, tvoShowRoot, tvoToolTips, tvoThemedDraw]
     end
     object pnlTreeLabel: TPanel
       Left = 0
@@ -348,12 +348,35 @@ object frmMain: TfrmMain
       object N5: TMenuItem
         Caption = '-'
       end
+      object itmCollapseAll: TMenuItem
+        Caption = 'Collapse All'
+        ShortCut = 24661
+        OnClick = itmCollapseAllClick
+      end
+      object itmCollapseChildren: TMenuItem
+        Caption = 'Collapse Children'
+        ShortCut = 16469
+        OnClick = itmCollapseChildrenClick
+      end
+      object itmExpandAll: TMenuItem
+        Caption = 'Expand All'
+        ShortCut = 24649
+        OnClick = itmExpandAllClick
+      end
+      object itmExpandChildren: TMenuItem
+        Caption = 'Expand Children'
+        ShortCut = 16457
+        OnClick = itmExpandChildrenClick
+      end
+      object N3: TMenuItem
+        Caption = '-'
+      end
       object itmDarkUnusedSectors: TMenuItem
         Caption = '&Darken Unused Sectors'
         Hint = 'Toggle whether unused sectors are shown darker'
         OnClick = itmDarkUnusedSectorsClick
       end
-      object N3: TMenuItem
+      object Separator3: TMenuItem
         Caption = '-'
       end
       object itmOptions: TMenuItem

--- a/Source/Main.pas
+++ b/Source/Main.pas
@@ -49,6 +49,10 @@ type
     itmFileSector: TMenuItem;
     itmSaveHeaderlessFile: TMenuItem;
     itmSaveSelectedHeaderlessFiles: TMenuItem;
+    itmCollapseAll: TMenuItem;
+    itmExpandAll: TMenuItem;
+    itmCollapseChildren: TMenuItem;
+    itmExpandChildren: TMenuItem;
     mnuMain: TMainMenu;
     itmDisk: TMenuItem;
     itmOpen: TMenuItem;
@@ -71,6 +75,7 @@ type
     Separator1: TMenuItem;
     itmCopySep: TMenuItem;
     Separator2: TMenuItem;
+    Separator3: TMenuItem;
     splVertical: TSplitter;
     statusBar: TStatusBar;
     pnlRight: TPanel;
@@ -118,7 +123,11 @@ type
     itmFind: TMenuItem;
     itmFindNext: TMenuItem;
     dlgFind: TFindDialog;
+    procedure itmCollapseAllClick(Sender: TObject);
+    procedure itmCollapseChildrenClick(Sender: TObject);
     procedure itmCopyMapToClipboardClick(Sender: TObject);
+    procedure itmExpandAllClick(Sender: TObject);
+    procedure itmExpandChildrenClick(Sender: TObject);
     procedure itmFileSectorClick(Sender: TObject);
     procedure itmOpenClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
@@ -527,6 +536,50 @@ begin
   Clipboard.Assign(MapImage);
   MapImage.Free;
 
+end;
+
+procedure TfrmMain.itmExpandAllClick(Sender: TObject);
+var
+  Node: TTreeNode;
+begin
+  tvwMain.Items.BeginUpdate;
+  try
+    Node := tvwMain.Items.GetFirstNode;
+    while Node <> nil do
+    begin
+      Node.Expand(True);  // Recursively expands this node and all children
+      Node := Node.GetNextSibling;  // Move to next sibling, not next in hierarchy
+    end;
+  finally
+    tvwMain.Items.EndUpdate;
+  end;
+end;
+
+procedure TfrmMain.itmExpandChildrenClick(Sender: TObject);
+begin
+  tvwMain.Selected.Expand(True);
+end;
+
+procedure TfrmMain.itmCollapseAllClick(Sender: TObject);
+var
+  Node: TTreeNode;
+begin
+  tvwMain.Items.BeginUpdate;
+  try
+    Node := tvwMain.Items.GetFirstNode;
+    while Node <> nil do
+    begin
+      Node.Collapse(True);
+      Node := Node.GetNextSibling;
+    end;
+  finally
+    tvwMain.Items.EndUpdate;
+  end;
+end;
+
+procedure TfrmMain.itmCollapseChildrenClick(Sender: TObject);
+begin
+  tvwMain.Selected.Collapse(True);
 end;
 
 procedure TfrmMain.itmFileSectorClick(Sender: TObject);


### PR DESCRIPTION
Add tree view expand/collapse global and parental features with menus and shortcuts for dealing with lots of disk images open at the same time.