### PR TITLE
Allow string view to be configured

### DIFF
--- a/Source/DskImage.pas
+++ b/Source/DskImage.pas
@@ -1108,7 +1108,6 @@ var
 begin
   Result := TStringList.Create;
   Result.Duplicates := DupIgnore;
-  Result.Sorted := True;
   CurrentText := '';
   Sector := Side[0].Track[0].Sector[0];
   Index := Sides;

--- a/Source/Main.lfm
+++ b/Source/Main.lfm
@@ -1,10 +1,10 @@
 object frmMain: TfrmMain
-  Left = 2284
-  Height = 378
-  Top = 699
+  Left = 1736
+  Height = 372
+  Top = 593
   Width = 556
   AllowDropFiles = True
-  ClientHeight = 378
+  ClientHeight = 372
   ClientWidth = 556
   Color = clBtnFace
   Font.CharSet = ANSI_CHARSET
@@ -17,24 +17,24 @@ object frmMain: TfrmMain
   OnCreate = FormCreate
   object splVertical: TSplitter
     Left = 180
-    Height = 329
+    Height = 323
     Top = 26
     Width = 4
   end
   object pnlLeft: TPanel
     Left = 0
-    Height = 329
+    Height = 323
     Top = 26
     Width = 180
     Align = alLeft
     BevelOuter = bvNone
-    ClientHeight = 329
+    ClientHeight = 323
     ClientWidth = 180
     ParentBackground = False
     TabOrder = 0
     object tvwMain: TTreeView
       Left = 0
-      Height = 310
+      Height = 304
       Top = 19
       Width = 180
       Align = alClient
@@ -67,25 +67,25 @@ object frmMain: TfrmMain
   object statusBar: TStatusBar
     Left = 0
     Height = 23
-    Top = 355
+    Top = 349
     Width = 556
     AutoHint = True
     Panels = <>
   end
   object pnlRight: TPanel
     Left = 184
-    Height = 329
+    Height = 323
     Top = 26
     Width = 372
     Align = alClient
     BevelOuter = bvNone
-    ClientHeight = 329
+    ClientHeight = 323
     ClientWidth = 372
     ParentBackground = False
     TabOrder = 1
     object DiskMap: TSpinDiskMap
       Left = 0
-      Height = 310
+      Height = 304
       Top = 19
       Width = 372
       Align = alClient
@@ -99,7 +99,7 @@ object frmMain: TfrmMain
     end
     object lvwMain: TListView
       Left = 0
-      Height = 310
+      Height = 304
       Top = 19
       Width = 372
       Align = alClient
@@ -135,21 +135,25 @@ object frmMain: TfrmMain
     end
     object pnlMemo: TPanel
       Left = 0
-      Height = 310
+      Height = 304
       Top = 19
       Width = 372
       Align = alClient
       BevelOuter = bvLowered
-      ClientHeight = 310
+      ClientHeight = 304
       ClientWidth = 372
       ParentBackground = False
       TabOrder = 2
       object memo: TMemo
         Left = 1
-        Height = 308
+        Height = 302
         Top = 1
         Width = 370
         Align = alClient
+        Font.CharSet = ANSI_CHARSET
+        Font.Pitch = fpVariable
+        Font.Quality = fqDraft
+        ParentFont = False
         ReadOnly = True
         ScrollBars = ssAutoBoth
         TabOrder = 0

--- a/Source/Main.pas
+++ b/Source/Main.pas
@@ -1513,12 +1513,19 @@ var
   Idx: integer;
   Strings: TStringList;
 begin
-  Strings := Disk.GetAllStrings(4, 4);
+  Strings := Disk.GetAllStrings(Settings.StringMinLength, 4);
   memo.Clear;
   lvwMain.Hide;
+
+  if Settings.StringSort = 'Alpha' then
+     Strings.Sort;
+  if Settings.StringSort = 'Size' then
+     Strings.CustomSort(CompareByLength);
+
   for Idx := 0 to Strings.Count - 1 do
     memo.Lines.Append(Strings[Idx]);
   memo.Lines.Delete(memo.Lines.Count - 1);
+
   pnlMemo.Show;
 end;
 

--- a/Source/Options.lfm
+++ b/Source/Options.lfm
@@ -1,7 +1,7 @@
 object frmOptions: TfrmOptions
-  Left = 760
+  Left = 2007
   Height = 359
-  Top = 472
+  Top = 502
   Width = 306
   BorderStyle = bsDialog
   Caption = 'Options'
@@ -13,7 +13,7 @@ object frmOptions: TfrmOptions
   Font.Height = -11
   Font.Name = 'Tahoma'
   Position = poMainFormCenter
-  LCLVersion = '2.2.4.0'
+  LCLVersion = '4.2.0.0'
   object pnlButtons: TPanel
     Left = 0
     Height = 28
@@ -23,6 +23,7 @@ object frmOptions: TfrmOptions
     BevelOuter = bvNone
     ClientHeight = 28
     ClientWidth = 306
+    ParentBackground = False
     TabOrder = 0
     object btnOK: TButton
       Left = 142
@@ -53,8 +54,8 @@ object frmOptions: TfrmOptions
       Width = 75
       Anchors = [akTop, akRight]
       Caption = 'Reset'
-      OnClick = btnResetClick
       TabOrder = 2
+      OnClick = btnResetClick
     end
   end
   object pnlTabs: TPanel
@@ -67,15 +68,16 @@ object frmOptions: TfrmOptions
     BorderWidth = 5
     ClientHeight = 331
     ClientWidth = 306
+    ParentBackground = False
     TabOrder = 1
     object pagOptions: TPageControl
       Left = 5
       Height = 321
       Top = 5
       Width = 296
-      ActivePage = tabMain
+      ActivePage = tabStrings
       Align = alClient
-      TabIndex = 0
+      TabIndex = 3
       TabOrder = 0
       object tabMain: TTabSheet
         Caption = 'Main'
@@ -110,23 +112,23 @@ object frmOptions: TfrmOptions
           Font.Pitch = fpVariable
           Font.Quality = fqDraft
           Font.Style = [fsBold, fsItalic]
-          OnClick = btnFontMainClick
           ParentFont = False
           TabOrder = 0
+          OnClick = btnFontMainClick
         end
         object chkRestoreWindow: TCheckBox
           Left = 8
-          Height = 19
+          Height = 17
           Top = 77
-          Width = 192
+          Width = 190
           Caption = 'Remember window position and size'
           TabOrder = 1
         end
         object chkRestoreWorkspace: TCheckBox
           Left = 8
-          Height = 19
+          Height = 17
           Top = 101
-          Width = 125
+          Width = 123
           Caption = 'Remember workspace'
           TabOrder = 2
         end
@@ -154,6 +156,14 @@ object frmOptions: TfrmOptions
           )
           Style = csDropDownList
           TabOrder = 4
+        end
+        object chkExpandRestoredFiles: TCheckBox
+          Left = 24
+          Height = 17
+          Top = 125
+          Width = 178
+          Caption = 'Expand top-level of restored files'
+          TabOrder = 5
         end
       end
       object tabSectors: TTabSheet
@@ -206,9 +216,9 @@ object frmOptions: TfrmOptions
           Font.Pitch = fpVariable
           Font.Quality = fqDraft
           Font.Style = [fsBold, fsItalic]
-          OnClick = btnFontSectorClick
           ParentFont = False
           TabOrder = 0
+          OnClick = btnFontSectorClick
         end
         object edtBytes: TEdit
           Left = 75
@@ -240,9 +250,9 @@ object frmOptions: TfrmOptions
         end
         object chkWarnSectorChange: TCheckBox
           Left = 8
-          Height = 19
+          Height = 17
           Top = 152
-          Width = 214
+          Width = 212
           Caption = 'Warn before changing data or FDC flags'
           TabOrder = 4
         end
@@ -323,9 +333,9 @@ object frmOptions: TfrmOptions
           Font.Pitch = fpVariable
           Font.Quality = fqDraft
           Font.Style = [fsBold, fsItalic]
-          OnClick = btnFontMapClick
           ParentFont = False
           TabOrder = 0
+          OnClick = btnFontMapClick
         end
         object udTrackMarks: TUpDown
           Left = 108
@@ -344,18 +354,18 @@ object frmOptions: TfrmOptions
           Top = 77
           Width = 33
           MaxLength = 3
-          OnChange = edtTrackMarksChange
           TabOrder = 3
           Text = '1'
+          OnChange = edtTrackMarksChange
         end
         object chkDarkBlankSectors: TCheckBox
           Left = 163
-          Height = 19
+          Height = 17
           Top = 77
-          Width = 118
+          Width = 116
           Caption = 'Dark unused sectors'
-          OnClick = chkDarkBlankSectorsClick
           TabOrder = 2
+          OnClick = chkDarkBlankSectorsClick
         end
         object cbxBack: TColorButton
           Left = 8
@@ -378,6 +388,95 @@ object frmOptions: TfrmOptions
           ButtonColor = clBlack
           Caption = 'Grid colour'
           OnColorChanged = cbxGridColorChanged
+        end
+      end
+      object tabStrings: TTabSheet
+        Caption = 'Strings'
+        ClientHeight = 295
+        ClientWidth = 288
+        object lblFontStringsLabel: TLabel
+          Left = 8
+          Height = 13
+          Top = 16
+          Width = 22
+          Caption = 'Font'
+          ParentColor = False
+        end
+        object edtFontStrings: TEdit
+          Left = 75
+          Height = 21
+          Top = 13
+          Width = 170
+          ReadOnly = True
+          TabOrder = 0
+        end
+        object btnFontStrings: TButton
+          Left = 249
+          Height = 21
+          Top = 13
+          Width = 20
+          Caption = 'A'
+          Font.CharSet = ANSI_CHARSET
+          Font.Color = clWindowText
+          Font.Height = -11
+          Font.Name = 'Times New Roman'
+          Font.Pitch = fpVariable
+          Font.Quality = fqDraft
+          Font.Style = [fsBold, fsItalic]
+          ParentFont = False
+          TabOrder = 1
+          OnClick = btnFontStringsClick
+        end
+        object lblMinStringLabel: TLabel
+          Left = 8
+          Height = 13
+          Top = 48
+          Width = 49
+          Caption = 'Min length'
+          ParentColor = False
+        end
+        object edtMinString: TEdit
+          Left = 75
+          Height = 21
+          Top = 44
+          Width = 33
+          MaxLength = 3
+          TabOrder = 2
+          Text = '1'
+          OnChange = edtTrackMarksChange
+        end
+        object udMinString: TUpDown
+          Left = 108
+          Height = 21
+          Top = 44
+          Width = 15
+          Associate = edtMinString
+          Max = 255
+          Min = 1
+          Position = 1
+          TabOrder = 3
+        end
+        object lblStringSorting: TLabel
+          Left = 8
+          Height = 13
+          Top = 81
+          Width = 34
+          Caption = 'Sorting'
+          ParentColor = False
+        end
+        object cboStringSorting: TComboBox
+          Left = 72
+          Height = 21
+          Top = 77
+          Width = 172
+          ItemHeight = 13
+          Items.Strings = (
+            'None'
+            'Alpha A > Z'
+            'Length Long > Short'
+          )
+          Style = csDropDownList
+          TabOrder = 4
         end
       end
       object tabSaving: TTabSheet
@@ -403,17 +502,17 @@ object frmOptions: TfrmOptions
         end
         object chkWarnConversionProblems: TCheckBox
           Left = 8
-          Height = 19
+          Height = 17
           Top = 16
-          Width = 199
+          Width = 197
           Caption = 'Warn about disk conversion problems'
           TabOrder = 0
         end
         object chkSaveRemoveEmptyTracks: TCheckBox
           Left = 8
-          Height = 19
+          Height = 17
           Top = 40
-          Width = 196
+          Width = 194
           Caption = 'Remove unformatted tracks from file'
           TabOrder = 1
         end

--- a/Source/Options.pas
+++ b/Source/Options.pas
@@ -15,17 +15,25 @@ interface
 
 uses
   DiskMap, Utils, Settings,
-  Graphics, Forms, ComCtrls, StdCtrls, Controls, ExtCtrls, Dialogs, StrUtils;
+  Graphics, Forms, ComCtrls, StdCtrls, Controls, ExtCtrls, Dialogs, StrUtils, Classes;
 
 type
 
   { TfrmOptions }
 
   TfrmOptions = class(TForm)
+    btnFontStrings: TButton;
+    cboStringSorting: TComboBox;
     cboOpenView: TComboBox;
     cboHighASCII: TComboBox;
+    chkExpandRestoredFiles: TCheckBox;
+    edtFontStrings: TEdit;
+    edtMinString: TEdit;
     lblDefaultView: TLabel;
+    lblFontStringsLabel: TLabel;
     lblMapping: TLabel;
+    lblStringSorting: TLabel;
+    lblMinStringLabel: TLabel;
     pnlButtons: TPanel;
     pagOptions: TPageControl;
     tabMain: TTabSheet;
@@ -45,6 +53,7 @@ type
     edtFontSector: TEdit;
     btnFontSector: TButton;
     lblTrackMarksLabel: TLabel;
+    tabStrings: TTabSheet;
     udTrackMarks: TUpDown;
     edtTrackMarks: TEdit;
     lblBytesLabel: TLabel;
@@ -69,6 +78,8 @@ type
     udMapY: TUpDown;
     chkWarnSectorChange: TCheckBox;
     pnlTabs: TPanel;
+    udMinString: TUpDown;
+    procedure btnFontStringsClick(Sender: TObject);
     procedure cbxBackColorChanged(Sender: TObject);
     procedure btnFontMainClick(Sender: TObject);
     procedure btnFontMapClick(Sender: TObject);
@@ -78,7 +89,7 @@ type
     procedure btnResetClick(Sender: TObject);
     procedure chkDarkBlankSectorsClick(Sender: TObject);
   private
-    FontMain, FontSector: TFont;
+    FontMain, FontSector, FontStrings: TFont;
     Settings: TSettings;
     procedure Read;
     procedure Write;
@@ -89,6 +100,7 @@ type
 
 const
   HighASCIIOptions: array[0..3] of string = ('None', '437', '850', '1252');
+  StringSortOptions: array[0..2] of string = ('None', 'Alpha', 'Size');
 
 var
   frmOptions: TfrmOptions;
@@ -106,6 +118,19 @@ end;
 procedure TfrmOptions.cbxBackColorChanged(Sender: TObject);
 begin
   DiskMap.Color := cbxBack.ButtonColor;
+end;
+
+procedure TfrmOptions.btnFontStringsClick(Sender: TObject);
+begin
+  with dlgFont do
+  begin
+    Font := FontStrings;
+    if Execute then
+    begin
+      edtFontStrings.Text := FontHumanReadable(Font);
+      FontStrings := Font;
+    end;
+  end;
 end;
 
 procedure TfrmOptions.btnFontMainClick(Sender: TObject);
@@ -161,7 +186,10 @@ begin
   Read;
   Result := ShowModal = mrOk;
   if Result then
+  begin
     Write;
+    Settings.Apply;
+  end;
 end;
 
 procedure TfrmOptions.Read;
@@ -176,6 +204,9 @@ begin
 
     DiskMap.Font := DiskMapFont;
     edtFontMap.Text := FontHumanReadable(DiskMapFont);
+
+    FontStrings := StringsFont;
+    edtFontStrings.Text := FontHumanReadable(StringsFont);
 
     chkRestoreWindow.Checked := RestoreWindow;
     chkRestoreWorkspace.Checked := RestoreWorkspace;
@@ -193,6 +224,8 @@ begin
     udMapX.Position := SaveDiskMapWidth;
     udMapY.Position := SaveDiskMapHeight;
     cboOpenView.Text := OpenView;
+    udMinString.Position := StringMinLength;
+    cboStringSorting.ItemIndex := IndexStr(StringSort, StringSortOptions);
   end;
 end;
 
@@ -203,6 +236,7 @@ begin
     WindowFont := FontMain;
     SectorFont := FontSector;
     DiskMapFont := DiskMap.Font;
+    StringsFont := FontStrings;
 
     DiskMapBackgroundColor := cbxBack.ButtonColor;
     DarkBlankSectors := chkDarkBlankSectors.Checked;

--- a/Source/Utils.pas
+++ b/Source/Utils.pas
@@ -41,6 +41,7 @@ function FontHumanReadable(ThisFont: TFont): string;
 function FontCopy(ThisFont: TFont): TFont;
 
 function StrFileSize(Size: integer): string;
+function CompareByLength(List: TStringList; Index1, Index2: Integer): Integer;
 
 procedure DrawBorder(Canvas: TCanvas; var Rect: TRect; BorderStyle: TSpinBorderStyle);
 
@@ -284,6 +285,13 @@ begin
          Result := Format('%d KB', [Size div 1024])
       else
           Result := Format('%d MB', [Size div Megabyte]);
+end;
+
+function CompareByLength(List: TStringList; Index1, Index2: Integer): Integer;
+begin
+  Result := Length(List[Index2]) - Length(List[Index1]);  // Longest first
+  if Result = 0 then
+    Result := CompareText(List[Index1], List[Index2]);  // Alphabetical if same length
 end;
 
 end.

--- a/Source/settings.pas
+++ b/Source/settings.pas
@@ -44,6 +44,11 @@ type
     OpenView: string;
     RecentFiles: TStringList;
 
+    // Strings
+    StringsFont: TFont;
+    StringMinLength: integer;
+    StringSort: string;
+
     // Saving
     WarnConversionProblems: boolean;
     RemoveEmptyTracks: boolean;
@@ -80,6 +85,7 @@ begin
     DiskMap.GridColor := DiskMapGridColor;
     DiskMap.Color := DiskMapBackgroundColor;
     DiskMap.TrackMark := DiskMapTrackMark;
+    memo.Font := StringsFont;
   end;
 end;
 
@@ -124,6 +130,11 @@ begin
   SectorFont := FontFromDescription(Reg.ReadString(S, 'Font', 'Consolas,8pt,,'));
   WarnSectorChange := Reg.ReadBool(S, 'WarnSectorChange', True);
   Mapping := Reg.ReadString(S, 'Mapping', '1252');
+
+  S := 'StringsView';
+  StringsFont := FontFromDescription(Reg.ReadString(S, 'Font', 'Tahoma,8pt,,'));
+  StringMinLength := Reg.ReadInteger(S, 'MinLength', 5);
+  StringSort := Reg.ReadString(S, 'Sort', 'Alpha');
 
   S := 'Workspace';
   RestoreWorkspace := Reg.ReadBool(S, 'Restore', False);
@@ -197,6 +208,11 @@ begin
   Reg.WriteString(S, 'Font', FontToDescription(SectorFont));
   Reg.WriteBool(S, 'WarnSectorChange', WarnSectorChange);
   Reg.WriteString(S, 'Mapping', Mapping);
+
+  S := 'StringsView';
+  Reg.WriteString(S, 'Font', FontToDescription(StringsFont));
+  Reg.WriteInteger(S, 'MinLength', StringMinLength);
+  Reg.WriteString(S, 'Sort', StringSort);
 
   S := 'Workspace';
   Reg.EraseSection(S);


### PR DESCRIPTION
Allows the sort-order, min string length and font to be configured for the strings view

<img width="320" height="395" alt="image" src="https://github.com/user-attachments/assets/e68d7bdd-62f9-47fd-8735-c3ffe2cfe5a3" />
